### PR TITLE
Balanced contentSize observer

### DIFF
--- a/KoaPullToRefresh/KoaPullToRefresh.m
+++ b/KoaPullToRefresh/KoaPullToRefresh.m
@@ -107,6 +107,7 @@ static char UIScrollViewPullToRefreshView;
     if(!showsPullToRefresh) {
         if (self.pullToRefreshView.isObserving) {
             [self removeObserver:self.pullToRefreshView forKeyPath:@"contentOffset"];
+            [self removeObserver:self.pullToRefreshView forKeyPath:@"contentSize"];
             [self removeObserver:self.pullToRefreshView forKeyPath:@"frame"];
             [self.pullToRefreshView resetScrollViewContentInset];
             self.pullToRefreshView.isObserving = NO;


### PR DESCRIPTION
The contentSize observer was not being removed when calling -setShowsPullToRefresh with NO
